### PR TITLE
feat: enable tick backtests and richer execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,28 @@ cargo run -p tesser-cli -- \
 
 Swap in `examples/strategies/rsi_reversion.toml` (or any file under `research/`) to compare behaviors. Omit `--data` to fall back to synthetic candles, or add multiple CSV paths to stitch larger datasets.
 
+### Tick-Level Backtests & Advanced Execution
+
+The CLI now understands both candle- and tick-driven simulations. Pass `--mode tick` to `tesser-cli backtest run` alongside one or more Level 2 / trade JSONL files:
+
+```sh
+cargo run -p tesser-cli -- \
+  backtest run \
+  --strategy-config research/strategies/orderbook_scalper.toml \
+  --mode tick \
+  --lob-data data/btcusdt/orderbook.jsonl data/btcusdt/trades.jsonl
+```
+
+In tick mode the backtester replays historical depth snapshots through the high-fidelity `MatchingEngine`, honoring your strategy's limit prices, conditional orders, and latency requirements. This path is ideal for testing microstructure-sensitive strategies and validating slippage assumptions.
+
+Execution hints now support specialized algorithms (configured through your strategies):
+
+- `ExecutionHint::PeggedBest` – refreshes IOC slices at the top of book (used by the new `OrderBookScalper`).
+- `ExecutionHint::Sniper` – waits for a target price before sweeping liquidity (used by the `VolatilitySkew` playbook).
+- Existing hints (`Twap`, `Vwap`, `IcebergSimulated`) continue to work unchanged, and their state is persisted via SQLite so in-flight schedules recover from process restarts.
+
+Additional indicators (ATR, MACD, Ichimoku Cloud) and reference strategies (`OrderBookScalper`, `CrossExchangeArb`, `VolatilitySkew`) ship with the workspace to showcase how these hints and the matching engine interact end to end.
+
 ### CLI Overview
 
 `tesser-cli` is the single entry point for local research and operations:

--- a/connectors/tesser-paper/src/conditional.rs
+++ b/connectors/tesser-paper/src/conditional.rs
@@ -1,0 +1,200 @@
+use std::collections::{HashMap, HashSet};
+
+use chrono::{DateTime, Utc};
+use tesser_core::{Candle, Order, Price, Side};
+
+/// Internal classification for conditional orders (used for OCO resolution).
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum TriggerKind {
+    Standalone,
+    StopLoss,
+    TakeProfit,
+}
+
+impl TriggerKind {
+    fn priority(self) -> u8 {
+        match self {
+            Self::StopLoss => 0,
+            Self::TakeProfit => 1,
+            Self::Standalone => 2,
+        }
+    }
+}
+
+/// Triggered order metadata returned by the manager.
+pub struct TriggeredOrder {
+    pub order: Order,
+    pub fill_price: Price,
+    pub timestamp: DateTime<Utc>,
+    pub kind: TriggerKind,
+    pub group: Option<String>,
+}
+
+struct PendingConditional {
+    order: Order,
+    kind: TriggerKind,
+    group: Option<String>,
+}
+
+/// Maintains a queue of conditional orders (stop-loss, take-profit, etc.).
+#[derive(Default)]
+pub struct ConditionalOrderManager {
+    orders: Vec<PendingConditional>,
+}
+
+impl ConditionalOrderManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a conditional order so it may be triggered later.
+    pub fn push(&mut self, order: Order) {
+        let (group, kind) = parse_group(&order);
+        self.orders.push(PendingConditional { order, kind, group });
+    }
+
+    /// Trigger any orders touched by the provided candle range.
+    pub fn trigger_with_candle(&mut self, candle: &Candle) -> Vec<TriggeredOrder> {
+        self.evaluate(|pending| {
+            let trigger = pending.order.request.trigger_price?;
+            let touched = match pending.order.request.side {
+                Side::Buy => candle.high >= trigger,
+                Side::Sell => candle.low <= trigger,
+            };
+            touched.then_some((trigger, candle.timestamp))
+        })
+    }
+
+    /// Trigger any orders whose thresholds were crossed by the provided trade price.
+    pub fn trigger_with_price(
+        &mut self,
+        last_price: Price,
+        timestamp: DateTime<Utc>,
+    ) -> Vec<TriggeredOrder> {
+        self.evaluate(|pending| {
+            let trigger = pending.order.request.trigger_price?;
+            let touched = match pending.order.request.side {
+                Side::Buy => last_price >= trigger,
+                Side::Sell => last_price <= trigger,
+            };
+            touched.then_some((last_price, timestamp))
+        })
+    }
+
+    fn evaluate<F>(&mut self, evaluator: F) -> Vec<TriggeredOrder>
+    where
+        F: Fn(&PendingConditional) -> Option<(Price, DateTime<Utc>)>,
+    {
+        let mut survivors = Vec::with_capacity(self.orders.len());
+        let mut triggered = Vec::new();
+        for pending in self.orders.drain(..) {
+            if let Some((price, ts)) = evaluator(&pending) {
+                triggered.push(TriggeredOrder {
+                    order: pending.order,
+                    fill_price: price,
+                    timestamp: ts,
+                    kind: pending.kind,
+                    group: pending.group.clone(),
+                });
+            } else {
+                survivors.push(pending);
+            }
+        }
+
+        let mut drop_groups = HashSet::new();
+        let mut resolved = Vec::new();
+        let mut grouped: HashMap<String, Vec<TriggeredOrder>> = HashMap::new();
+        for event in triggered.into_iter() {
+            if let Some(group) = &event.group {
+                grouped.entry(group.clone()).or_default().push(event);
+            } else {
+                resolved.push(event);
+            }
+        }
+
+        for (group, mut events) in grouped.into_iter() {
+            events.sort_by_key(|event| event.kind.priority());
+            if let Some(best) = events.into_iter().next() {
+                drop_groups.insert(group);
+                resolved.push(best);
+            }
+        }
+
+        self.orders = survivors
+            .into_iter()
+            .filter(|pending| {
+                pending
+                    .group
+                    .as_ref()
+                    .map(|group| !drop_groups.contains(group))
+                    .unwrap_or(true)
+            })
+            .collect();
+
+        resolved
+    }
+}
+
+fn parse_group(order: &Order) -> (Option<String>, TriggerKind) {
+    if let Some(cid) = order.request.client_order_id.as_ref() {
+        if let Some(base) = cid.strip_suffix("-sl") {
+            return (Some(base.to_string()), TriggerKind::StopLoss);
+        }
+        if let Some(base) = cid.strip_suffix("-tp") {
+            return (Some(base.to_string()), TriggerKind::TakeProfit);
+        }
+    }
+    (None, TriggerKind::Standalone)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal::Decimal;
+    use tesser_core::{OrderRequest, OrderStatus, Quantity, TimeInForce};
+    use uuid::Uuid;
+
+    fn pending(side: Side, trigger: Price, cid: &str) -> Order {
+        Order {
+            id: Uuid::new_v4().to_string(),
+            request: OrderRequest {
+                symbol: "BTCUSDT".into(),
+                side,
+                order_type: tesser_core::OrderType::StopMarket,
+                quantity: Quantity::from(1),
+                price: None,
+                trigger_price: Some(trigger),
+                time_in_force: Some(TimeInForce::GoodTilCanceled),
+                client_order_id: Some(cid.into()),
+                take_profit: None,
+                stop_loss: None,
+                display_quantity: None,
+            },
+            status: OrderStatus::PendingNew,
+            filled_quantity: Quantity::ZERO,
+            avg_fill_price: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn stop_loss_wins_over_take_profit() {
+        let mut book = ConditionalOrderManager::new();
+        book.push(pending(Side::Sell, Decimal::from(90), "base-sl"));
+        book.push(pending(Side::Sell, Decimal::from(110), "base-tp"));
+        let candle = Candle {
+            symbol: "BTCUSDT".into(),
+            interval: tesser_core::Interval::OneMinute,
+            open: Decimal::from(100),
+            high: Decimal::from(120),
+            low: Decimal::from(80),
+            close: Decimal::from(95),
+            volume: Decimal::from(1),
+            timestamp: Utc::now(),
+        };
+        let triggered = book.trigger_with_candle(&candle);
+        assert_eq!(triggered.len(), 1);
+        assert_eq!(triggered[0].kind, TriggerKind::StopLoss);
+    }
+}

--- a/tesser-backtester/src/lib.rs
+++ b/tesser-backtester/src/lib.rs
@@ -301,7 +301,7 @@ impl Backtester {
                 }
                 MarketEventKind::Trade(tick) => {
                     matching
-                        .process_trade(tick.side, tick.price, tick.size)
+                        .process_trade(tick.side, tick.price, tick.size, tick.exchange_timestamp)
                         .await;
                     last_trade_price = Some(tick.price);
                     self.portfolio.mark_price(&tick.symbol, tick.price);

--- a/tesser-core/src/lib.rs
+++ b/tesser-core/src/lib.rs
@@ -36,6 +36,20 @@ pub enum ExecutionHint {
         #[serde(default)]
         limit_offset_bps: Option<Decimal>,
     },
+    /// Pegged-to-best style trading that refreshes a passive order at the top of book.
+    PeggedBest {
+        offset_bps: Decimal,
+        #[serde(default)]
+        clip_size: Option<Quantity>,
+        #[serde(default)]
+        refresh_secs: Option<u64>,
+    },
+    /// Sits on the sidelines until a target price is reached, then fires aggressively.
+    Sniper {
+        trigger_price: Price,
+        #[serde(default)]
+        timeout: Option<Duration>,
+    },
 }
 
 /// The side of an order or position.

--- a/tesser-execution/src/algorithm/mod.rs
+++ b/tesser-execution/src/algorithm/mod.rs
@@ -70,8 +70,12 @@ pub trait ExecutionAlgorithm: Send + Sync {
 }
 
 pub mod iceberg;
+pub mod pegged;
 pub mod twap;
 pub mod vwap;
 pub use iceberg::IcebergAlgorithm;
+pub use pegged::PeggedBestAlgorithm;
 pub use twap::TwapAlgorithm;
 pub use vwap::VwapAlgorithm;
+pub mod sniper;
+pub use sniper::SniperAlgorithm;

--- a/tesser-execution/src/algorithm/pegged.rs
+++ b/tesser-execution/src/algorithm/pegged.rs
@@ -1,0 +1,233 @@
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, Duration, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use tesser_core::{Order, OrderRequest, OrderType, Quantity, Signal, Tick, TimeInForce};
+use uuid::Uuid;
+
+use super::{AlgoStatus, ChildOrderRequest, ExecutionAlgorithm};
+
+#[derive(Debug, Deserialize, Serialize)]
+struct PeggedState {
+    id: Uuid,
+    parent_signal: Signal,
+    status: String,
+    total_quantity: Quantity,
+    filled_quantity: Quantity,
+    clip_size: Quantity,
+    offset_bps: Decimal,
+    refresh: Duration,
+    last_order_time: Option<DateTime<Utc>>,
+    last_peg_price: Option<Decimal>,
+    next_child_seq: u32,
+}
+
+/// Algorithm that repeatedly submits IOC limit orders pegged to the top of book.
+pub struct PeggedBestAlgorithm {
+    state: PeggedState,
+}
+
+impl PeggedBestAlgorithm {
+    pub fn new(
+        signal: Signal,
+        total_quantity: Quantity,
+        offset_bps: Decimal,
+        clip_size: Option<Quantity>,
+        refresh: Duration,
+    ) -> Result<Self> {
+        if total_quantity <= Decimal::ZERO {
+            return Err(anyhow!("pegged algorithm requires positive quantity"));
+        }
+        if offset_bps < Decimal::ZERO {
+            return Err(anyhow!("offset must be non-negative"));
+        }
+        if refresh <= Duration::zero() {
+            return Err(anyhow!("refresh interval must be positive"));
+        }
+        let clip = clip_size
+            .unwrap_or(total_quantity)
+            .max(Decimal::ZERO)
+            .min(total_quantity);
+        Ok(Self {
+            state: PeggedState {
+                id: Uuid::new_v4(),
+                parent_signal: signal,
+                status: "Working".into(),
+                total_quantity,
+                filled_quantity: Decimal::ZERO,
+                clip_size: if clip <= Decimal::ZERO {
+                    total_quantity
+                } else {
+                    clip
+                },
+                offset_bps,
+                refresh,
+                last_order_time: None,
+                last_peg_price: None,
+                next_child_seq: 0,
+            },
+        })
+    }
+
+    fn remaining(&self) -> Quantity {
+        (self.state.total_quantity - self.state.filled_quantity).max(Decimal::ZERO)
+    }
+
+    fn peg_price(&self, tick_price: Decimal) -> Decimal {
+        let offset = self.state.offset_bps / Decimal::from(10_000);
+        match self.state.parent_signal.kind.side() {
+            tesser_core::Side::Buy => tick_price * (Decimal::ONE - offset),
+            tesser_core::Side::Sell => tick_price * (Decimal::ONE + offset),
+        }
+    }
+
+    fn should_refresh(&self, price: Decimal, now: DateTime<Utc>) -> bool {
+        if self.last_emit_elapsed(now) >= self.state.refresh {
+            return true;
+        }
+        self.state
+            .last_peg_price
+            .map(|prev| (prev - price).abs() > Decimal::ZERO)
+            .unwrap_or(true)
+    }
+
+    fn last_emit_elapsed(&self, now: DateTime<Utc>) -> Duration {
+        self.state
+            .last_order_time
+            .map(|ts| now.signed_duration_since(ts))
+            .unwrap_or(self.state.refresh)
+    }
+
+    fn build_child(&mut self, price: Decimal, qty: Quantity) -> ChildOrderRequest {
+        self.state.next_child_seq += 1;
+        ChildOrderRequest {
+            parent_algo_id: self.state.id,
+            order_request: OrderRequest {
+                symbol: self.state.parent_signal.symbol.clone(),
+                side: self.state.parent_signal.kind.side(),
+                order_type: OrderType::Limit,
+                quantity: qty,
+                price: Some(price),
+                trigger_price: None,
+                time_in_force: Some(TimeInForce::ImmediateOrCancel),
+                client_order_id: Some(format!(
+                    "peg-{}-{}",
+                    self.state.id, self.state.next_child_seq
+                )),
+                take_profit: None,
+                stop_loss: None,
+                display_quantity: None,
+            },
+        }
+    }
+
+    fn mark_completed(&mut self) {
+        if self.remaining() <= Decimal::ZERO {
+            self.state.status = "Completed".into();
+        }
+    }
+}
+
+impl ExecutionAlgorithm for PeggedBestAlgorithm {
+    fn kind(&self) -> &'static str {
+        "PEGGED_BEST"
+    }
+
+    fn id(&self) -> &Uuid {
+        &self.state.id
+    }
+
+    fn status(&self) -> AlgoStatus {
+        match self.state.status.as_str() {
+            "Working" => AlgoStatus::Working,
+            "Completed" => AlgoStatus::Completed,
+            "Cancelled" => AlgoStatus::Cancelled,
+            other => AlgoStatus::Failed(other.to_string()),
+        }
+    }
+
+    fn start(&mut self) -> Result<Vec<ChildOrderRequest>> {
+        Ok(Vec::new())
+    }
+
+    fn on_child_order_placed(&mut self, _order: &Order) {
+        self.state.last_order_time = Some(Utc::now());
+    }
+
+    fn on_fill(&mut self, fill: &tesser_core::Fill) -> Result<Vec<ChildOrderRequest>> {
+        self.state.filled_quantity += fill.fill_quantity;
+        self.mark_completed();
+        Ok(Vec::new())
+    }
+
+    fn on_tick(&mut self, tick: &Tick) -> Result<Vec<ChildOrderRequest>> {
+        if !matches!(self.status(), AlgoStatus::Working) {
+            return Ok(Vec::new());
+        }
+        let remaining = self.remaining();
+        if remaining <= Decimal::ZERO {
+            self.state.status = "Completed".into();
+            return Ok(Vec::new());
+        }
+        let now = Utc::now();
+        let price = self.peg_price(tick.price.max(Decimal::ZERO));
+        if !self.should_refresh(price, now) {
+            return Ok(Vec::new());
+        }
+        self.state.last_peg_price = Some(price);
+        let qty = remaining.min(self.state.clip_size);
+        Ok(vec![self.build_child(price, qty)])
+    }
+
+    fn on_timer(&mut self) -> Result<Vec<ChildOrderRequest>> {
+        self.mark_completed();
+        Ok(Vec::new())
+    }
+
+    fn cancel(&mut self) -> Result<()> {
+        self.state.status = "Cancelled".into();
+        Ok(())
+    }
+
+    fn state(&self) -> serde_json::Value {
+        serde_json::to_value(&self.state).expect("pegged state serialization failed")
+    }
+
+    fn from_state(state: serde_json::Value) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let state: PeggedState = serde_json::from_value(state)?;
+        Ok(Self { state })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tesser_core::{Signal, SignalKind, Tick};
+
+    #[test]
+    fn emits_child_after_tick() {
+        let signal = Signal::new("BTCUSDT", SignalKind::EnterLong, 0.9);
+        let mut algo = PeggedBestAlgorithm::new(
+            signal,
+            Decimal::from(5),
+            Decimal::new(5, 1),
+            None,
+            Duration::seconds(1),
+        )
+        .unwrap();
+        let tick = Tick {
+            symbol: "BTCUSDT".into(),
+            price: Decimal::from(100),
+            size: Decimal::ONE,
+            side: tesser_core::Side::Buy,
+            exchange_timestamp: Utc::now(),
+            received_at: Utc::now(),
+        };
+        let orders = algo.on_tick(&tick).unwrap();
+        assert_eq!(orders.len(), 1);
+        assert!(orders[0].order_request.quantity > Decimal::ZERO);
+    }
+}

--- a/tesser-execution/src/algorithm/sniper.rs
+++ b/tesser-execution/src/algorithm/sniper.rs
@@ -1,0 +1,190 @@
+use anyhow::{anyhow, Result};
+use chrono::{Duration, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use tesser_core::{Order, OrderRequest, OrderType, Price, Quantity, Signal, SignalKind, Tick};
+use uuid::Uuid;
+
+use super::{AlgoStatus, ChildOrderRequest, ExecutionAlgorithm};
+
+#[derive(Debug, Deserialize, Serialize)]
+struct SniperState {
+    id: Uuid,
+    parent_signal: Signal,
+    status: String,
+    total_quantity: Quantity,
+    filled_quantity: Quantity,
+    trigger_price: Price,
+    timeout: Option<Duration>,
+    triggered: bool,
+    started_at: chrono::DateTime<Utc>,
+}
+
+/// Fires a single aggressive order once a target price is touched.
+pub struct SniperAlgorithm {
+    state: SniperState,
+}
+
+impl SniperAlgorithm {
+    pub fn new(
+        signal: Signal,
+        total_quantity: Quantity,
+        trigger_price: Price,
+        timeout: Option<Duration>,
+    ) -> Result<Self> {
+        if total_quantity <= Decimal::ZERO {
+            return Err(anyhow!("sniper quantity must be positive"));
+        }
+        if trigger_price <= Decimal::ZERO {
+            return Err(anyhow!("trigger price must be positive"));
+        }
+        Ok(Self {
+            state: SniperState {
+                id: Uuid::new_v4(),
+                parent_signal: signal,
+                status: "Working".into(),
+                total_quantity,
+                filled_quantity: Decimal::ZERO,
+                trigger_price,
+                timeout,
+                triggered: false,
+                started_at: Utc::now(),
+            },
+        })
+    }
+
+    fn remaining(&self) -> Quantity {
+        (self.state.total_quantity - self.state.filled_quantity).max(Decimal::ZERO)
+    }
+
+    fn ready_to_fire(&self, price: Price) -> bool {
+        match self.state.parent_signal.kind {
+            SignalKind::EnterLong | SignalKind::ExitShort => price <= self.state.trigger_price,
+            SignalKind::EnterShort | SignalKind::ExitLong => price >= self.state.trigger_price,
+            SignalKind::Flatten => false,
+        }
+    }
+
+    fn build_child(&mut self, qty: Quantity) -> ChildOrderRequest {
+        ChildOrderRequest {
+            parent_algo_id: self.state.id,
+            order_request: OrderRequest {
+                symbol: self.state.parent_signal.symbol.clone(),
+                side: self.state.parent_signal.kind.side(),
+                order_type: OrderType::Market,
+                quantity: qty,
+                price: None,
+                trigger_price: None,
+                time_in_force: None,
+                client_order_id: Some(format!("sniper-{}", self.state.id)),
+                take_profit: None,
+                stop_loss: None,
+                display_quantity: None,
+            },
+        }
+    }
+
+    fn check_expired(&mut self) {
+        if let Some(timeout) = self.state.timeout {
+            if Utc::now() - self.state.started_at >= timeout {
+                self.state.status = "Cancelled".into();
+            }
+        }
+    }
+}
+
+impl ExecutionAlgorithm for SniperAlgorithm {
+    fn kind(&self) -> &'static str {
+        "SNIPER"
+    }
+
+    fn id(&self) -> &Uuid {
+        &self.state.id
+    }
+
+    fn status(&self) -> AlgoStatus {
+        match self.state.status.as_str() {
+            "Working" => AlgoStatus::Working,
+            "Completed" => AlgoStatus::Completed,
+            "Cancelled" => AlgoStatus::Cancelled,
+            other => AlgoStatus::Failed(other.to_string()),
+        }
+    }
+
+    fn start(&mut self) -> Result<Vec<ChildOrderRequest>> {
+        Ok(Vec::new())
+    }
+
+    fn on_child_order_placed(&mut self, _order: &Order) {}
+
+    fn on_fill(&mut self, fill: &tesser_core::Fill) -> Result<Vec<ChildOrderRequest>> {
+        self.state.filled_quantity += fill.fill_quantity;
+        if self.remaining() <= Decimal::ZERO {
+            self.state.status = "Completed".into();
+        }
+        Ok(Vec::new())
+    }
+
+    fn on_tick(&mut self, tick: &Tick) -> Result<Vec<ChildOrderRequest>> {
+        if !matches!(self.status(), AlgoStatus::Working) {
+            return Ok(Vec::new());
+        }
+        if self.state.triggered {
+            return Ok(Vec::new());
+        }
+        if self.ready_to_fire(tick.price) {
+            self.state.triggered = true;
+            let qty = self.remaining();
+            if qty > Decimal::ZERO {
+                return Ok(vec![self.build_child(qty)]);
+            }
+        }
+        Ok(Vec::new())
+    }
+
+    fn on_timer(&mut self) -> Result<Vec<ChildOrderRequest>> {
+        self.check_expired();
+        Ok(Vec::new())
+    }
+
+    fn cancel(&mut self) -> Result<()> {
+        self.state.status = "Cancelled".into();
+        Ok(())
+    }
+
+    fn state(&self) -> serde_json::Value {
+        serde_json::to_value(&self.state).expect("sniper state serialization failed")
+    }
+
+    fn from_state(state: serde_json::Value) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let state: SniperState = serde_json::from_value(state)?;
+        Ok(Self { state })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tesser_core::{Signal, SignalKind, Tick};
+
+    #[test]
+    fn sniper_triggers_when_price_crosses() {
+        let signal = Signal::new("BTCUSDT", SignalKind::EnterLong, 0.5);
+        let mut algo =
+            SniperAlgorithm::new(signal, Decimal::from(2), Decimal::from(100), None).unwrap();
+        let tick = Tick {
+            symbol: "BTCUSDT".into(),
+            price: Decimal::from(95),
+            size: Decimal::ONE,
+            side: tesser_core::Side::Sell,
+            exchange_timestamp: Utc::now(),
+            received_at: Utc::now(),
+        };
+        let orders = algo.on_tick(&tick).unwrap();
+        assert_eq!(orders.len(), 1);
+        assert!(orders[0].order_request.order_type == OrderType::Market);
+    }
+}

--- a/tesser-indicators/src/indicators/atr.rs
+++ b/tesser-indicators/src/indicators/atr.rs
@@ -1,0 +1,102 @@
+//! Average True Range indicator implementation.
+
+use rust_decimal::Decimal;
+use tesser_core::Candle;
+
+use crate::core::{Indicator, IndicatorError};
+
+/// Average True Range indicator.
+pub struct Atr {
+    period: usize,
+    prev_close: Option<Decimal>,
+    atr: Option<Decimal>,
+    warmup_sum: Decimal,
+    warmup_count: usize,
+}
+
+impl Atr {
+    /// Create a new ATR indicator with the provided period.
+    pub fn new(period: usize) -> Result<Self, IndicatorError> {
+        if period == 0 {
+            return Err(IndicatorError::invalid_period("ATR", period));
+        }
+        Ok(Self {
+            period,
+            prev_close: None,
+            atr: None,
+            warmup_sum: Decimal::ZERO,
+            warmup_count: 0,
+        })
+    }
+
+    fn true_range(&self, candle: &Candle, prev_close: Decimal) -> Decimal {
+        let high_low = candle.high - candle.low;
+        let high_close = (candle.high - prev_close).abs();
+        let low_close = (candle.low - prev_close).abs();
+        high_low.max(high_close).max(low_close)
+    }
+}
+
+impl Indicator for Atr {
+    type Input = Candle;
+    type Output = Decimal;
+
+    fn next(&mut self, input: Self::Input) -> Option<Self::Output> {
+        let prev_close = self.prev_close.unwrap_or(input.close);
+        let tr = self.true_range(&input, prev_close);
+        self.prev_close = Some(input.close);
+
+        if let Some(current) = self.atr {
+            let factor = Decimal::from(self.period as i64 - 1);
+            let next = (current * factor + tr) / Decimal::from(self.period as i64);
+            self.atr = Some(next);
+            Some(next)
+        } else {
+            self.warmup_sum += tr;
+            self.warmup_count += 1;
+            if self.warmup_count == self.period {
+                let init = self.warmup_sum / Decimal::from(self.period as i64);
+                self.atr = Some(init);
+                self.warmup_sum = Decimal::ZERO;
+                Some(init)
+            } else {
+                None
+            }
+        }
+    }
+
+    fn reset(&mut self) {
+        self.prev_close = None;
+        self.atr = None;
+        self.warmup_sum = Decimal::ZERO;
+        self.warmup_count = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use tesser_core::{Interval, Symbol};
+
+    fn candle(close: f64) -> Candle {
+        Candle {
+            symbol: Symbol::from("BTCUSDT"),
+            interval: Interval::OneMinute,
+            open: Decimal::from_f64_retain(close).unwrap(),
+            high: Decimal::from_f64_retain(close + 5.0).unwrap(),
+            low: Decimal::from_f64_retain(close - 5.0).unwrap(),
+            close: Decimal::from_f64_retain(close).unwrap(),
+            volume: Decimal::ONE,
+            timestamp: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn atr_warms_up() {
+        let mut atr = Atr::new(3).unwrap();
+        assert!(atr.next(candle(100.0)).is_none());
+        assert!(atr.next(candle(101.0)).is_none());
+        assert!(atr.next(candle(102.0)).is_some());
+    }
+}

--- a/tesser-indicators/src/indicators/ichimoku.rs
+++ b/tesser-indicators/src/indicators/ichimoku.rs
@@ -1,0 +1,148 @@
+//! Ichimoku Cloud indicator implementation.
+
+use std::collections::VecDeque;
+
+use rust_decimal::Decimal;
+use tesser_core::Candle;
+
+use crate::core::{Indicator, IndicatorError};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+/// Snapshot of the Ichimoku Cloud state.
+pub struct IchimokuOutput {
+    /// Tenkan-sen line value.
+    pub conversion_line: Decimal,
+    /// Kijun-sen line value.
+    pub base_line: Decimal,
+    /// Senkou Span A projection.
+    pub span_a: Decimal,
+    /// Senkou Span B projection.
+    pub span_b: Decimal,
+}
+
+/// Ichimoku Cloud indicator implementation.
+pub struct Ichimoku {
+    conversion_period: usize,
+    base_period: usize,
+    span_b_period: usize,
+    highs_conv: VecDeque<Decimal>,
+    lows_conv: VecDeque<Decimal>,
+    highs_base: VecDeque<Decimal>,
+    lows_base: VecDeque<Decimal>,
+    highs_span_b: VecDeque<Decimal>,
+    lows_span_b: VecDeque<Decimal>,
+}
+
+impl Ichimoku {
+    /// Build a new Ichimoku indicator with custom periods.
+    pub fn new(
+        conversion_period: usize,
+        base_period: usize,
+        span_b_period: usize,
+    ) -> Result<Self, IndicatorError> {
+        if conversion_period == 0 {
+            return Err(IndicatorError::invalid_period(
+                "Ichimoku",
+                conversion_period,
+            ));
+        }
+        if base_period == 0 {
+            return Err(IndicatorError::invalid_period("Ichimoku", base_period));
+        }
+        if span_b_period == 0 {
+            return Err(IndicatorError::invalid_period("Ichimoku", span_b_period));
+        }
+        Ok(Self {
+            conversion_period,
+            base_period,
+            span_b_period,
+            highs_conv: VecDeque::with_capacity(conversion_period),
+            lows_conv: VecDeque::with_capacity(conversion_period),
+            highs_base: VecDeque::with_capacity(base_period),
+            lows_base: VecDeque::with_capacity(base_period),
+            highs_span_b: VecDeque::with_capacity(span_b_period),
+            lows_span_b: VecDeque::with_capacity(span_b_period),
+        })
+    }
+
+    fn midpoint(highs: &VecDeque<Decimal>, lows: &VecDeque<Decimal>) -> Option<Decimal> {
+        let max_high = highs.iter().copied().reduce(Decimal::max)?;
+        let min_low = lows.iter().copied().reduce(Decimal::min)?;
+        Some((max_high + min_low) / Decimal::from(2))
+    }
+}
+
+impl Indicator for Ichimoku {
+    type Input = Candle;
+    type Output = IchimokuOutput;
+
+    fn next(&mut self, input: Self::Input) -> Option<Self::Output> {
+        push_queue(&mut self.highs_conv, self.conversion_period, input.high);
+        push_queue(&mut self.lows_conv, self.conversion_period, input.low);
+        push_queue(&mut self.highs_base, self.base_period, input.high);
+        push_queue(&mut self.lows_base, self.base_period, input.low);
+        push_queue(&mut self.highs_span_b, self.span_b_period, input.high);
+        push_queue(&mut self.lows_span_b, self.span_b_period, input.low);
+
+        if self.highs_span_b.len() < self.span_b_period {
+            return None;
+        }
+
+        let conversion = Self::midpoint(&self.highs_conv, &self.lows_conv)?;
+        let base = Self::midpoint(&self.highs_base, &self.lows_base)?;
+        let span_b = Self::midpoint(&self.highs_span_b, &self.lows_span_b)?;
+        let span_a = (conversion + base) / Decimal::from(2);
+
+        Some(IchimokuOutput {
+            conversion_line: conversion,
+            base_line: base,
+            span_a,
+            span_b,
+        })
+    }
+
+    fn reset(&mut self) {
+        self.highs_conv.clear();
+        self.lows_conv.clear();
+        self.highs_base.clear();
+        self.lows_base.clear();
+        self.highs_span_b.clear();
+        self.lows_span_b.clear();
+    }
+}
+
+fn push_queue(queue: &mut VecDeque<Decimal>, period: usize, value: Decimal) {
+    queue.push_back(value);
+    if queue.len() > period {
+        queue.pop_front();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use tesser_core::{Interval, Symbol};
+
+    fn candle(value: f64) -> Candle {
+        Candle {
+            symbol: Symbol::from("BTCUSDT"),
+            interval: Interval::OneMinute,
+            open: Decimal::from_f64_retain(value).unwrap(),
+            high: Decimal::from_f64_retain(value + 1.0).unwrap(),
+            low: Decimal::from_f64_retain(value - 1.0).unwrap(),
+            close: Decimal::from_f64_retain(value).unwrap(),
+            volume: Decimal::ONE,
+            timestamp: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn ichimoku_emits_after_warmup() {
+        let mut ichi = Ichimoku::new(2, 4, 4).unwrap();
+        for val in [1.0, 2.0, 3.0] {
+            assert!(ichi.next(candle(val)).is_none());
+        }
+        assert!(ichi.next(candle(4.0)).is_some());
+    }
+}

--- a/tesser-indicators/src/indicators/macd.rs
+++ b/tesser-indicators/src/indicators/macd.rs
@@ -1,0 +1,98 @@
+//! Moving Average Convergence Divergence indicator implementation.
+
+use rust_decimal::Decimal;
+
+use crate::core::{Indicator, IndicatorError};
+use crate::indicators::ema::Ema;
+
+/// MACD output (line, signal line, and histogram).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct MacdOutput {
+    /// MACD line value (fast EMA minus slow EMA).
+    pub macd: Decimal,
+    /// Signal line value (EMA of the MACD line).
+    pub signal: Decimal,
+    /// Histogram representing the distance between MACD and signal lines.
+    pub histogram: Decimal,
+}
+
+/// Moving Average Convergence Divergence indicator.
+pub struct Macd {
+    fast: Ema<Decimal>,
+    slow: Ema<Decimal>,
+    signal: Ema,
+    last_histogram: Option<Decimal>,
+}
+
+impl Macd {
+    /// Create a MACD indicator with custom fast/slow/signal periods.
+    pub fn new(
+        fast_period: usize,
+        slow_period: usize,
+        signal_period: usize,
+    ) -> Result<Self, IndicatorError> {
+        if fast_period == 0 {
+            return Err(IndicatorError::invalid_period("MACD", fast_period));
+        }
+        if slow_period == 0 {
+            return Err(IndicatorError::invalid_period("MACD", slow_period));
+        }
+        if signal_period == 0 {
+            return Err(IndicatorError::invalid_period("MACD", signal_period));
+        }
+        Ok(Self {
+            fast: Ema::new(fast_period)?,
+            slow: Ema::new(slow_period)?,
+            signal: Ema::new(signal_period)?,
+            last_histogram: None,
+        })
+    }
+}
+
+impl Indicator for Macd {
+    type Input = Decimal;
+    type Output = MacdOutput;
+
+    fn next(&mut self, input: Self::Input) -> Option<Self::Output> {
+        let fast = self.fast.next(input);
+        let slow = self.slow.next(input);
+        match (fast, slow) {
+            (Some(fast_val), Some(slow_val)) => {
+                let macd = fast_val - slow_val;
+                if let Some(signal_line) = self.signal.next(macd) {
+                    let histogram = macd - signal_line;
+                    self.last_histogram = Some(histogram);
+                    Some(MacdOutput {
+                        macd,
+                        signal: signal_line,
+                        histogram,
+                    })
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.fast.reset();
+        self.slow.reset();
+        self.signal.reset();
+        self.last_histogram = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn macd_emits_after_warmup() {
+        let mut macd = Macd::new(3, 6, 3).unwrap();
+        for price in 1..=15 {
+            macd.next(Decimal::from(price));
+        }
+        assert!(macd.next(Decimal::from(16)).is_some());
+    }
+}

--- a/tesser-indicators/src/indicators/mod.rs
+++ b/tesser-indicators/src/indicators/mod.rs
@@ -1,11 +1,20 @@
 //! Built-in indicator implementations provided by the crate.
 
+/// Average True Range indicator module.
+pub mod atr;
 pub mod bollinger;
 pub mod ema;
+/// Ichimoku Cloud indicator module.
+pub mod ichimoku;
+/// Moving Average Convergence Divergence module.
+pub mod macd;
 pub mod rsi;
 pub mod sma;
 
+pub use atr::Atr;
 pub use bollinger::{BollingerBands, BollingerBandsOutput};
 pub use ema::Ema;
+pub use ichimoku::{Ichimoku, IchimokuOutput};
+pub use macd::{Macd, MacdOutput};
 pub use rsi::Rsi;
 pub use sma::Sma;


### PR DESCRIPTION
## Summary

- Added tick-level backtesting support to `tesser-cli` and `tesser-backtester`, wiring `--mode tick` to the high-fidelity `MatchingEngine`, and enhanced `PaperExecutionClient` so conditional orders, stops, and bracket legs share the same trigger manager used by the matching engine.
- Expanded `tesser-execution` with fully orchestrated TWAP/VWAP/Iceberg flows, introduced Pegged-to-Best and Sniper execution algorithms, and persisted their state through `SqliteAlgoStateRepository` so in-flight schedules recover after restarts (with integration/unit tests).
- Richened the research toolkit by adding ATR, MACD, and Ichimoku indicators plus new showcase strategies (OrderBookScalper, CrossExchangeArb, VolatilitySkew) that demonstrate the fresh execution hints; README now documents tick backtests and advanced execution modes.

## Testing

- `cargo clippy`
- `cargo test -p tesser-execution -p tesser-indicators -p tesser-strategy`
