### PR TITLE
feat: add pub-sub event bus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2123,6 +2123,7 @@ dependencies = [
  "tesser-config",
  "tesser-core",
  "tesser-data",
+ "tesser-events",
  "tesser-execution",
  "tesser-paper",
  "tesser-portfolio",
@@ -2173,6 +2174,15 @@ dependencies = [
  "tesser-core",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "tesser-events"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "tesser-core",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "tesser-execution",
     "tesser-backtester",
     "tesser-cli",
+    "tesser-events",
     "connectors/tesser-bybit",
     "connectors/tesser-paper",
     "tesser-config", "tesser-indicators", "tesser-test-utils",

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ tesser/
 |
 ├── tesser-data         # Consumes data via the broker trait
 ├── tesser-execution    # Sends orders via the broker trait
+├── tesser-events       # In-process pub/sub event bus
 |
 ├── tesser-backtester   # The simulation engine
 ├── tesser-cli          # The command-line user interface
@@ -58,6 +59,11 @@ tesser/
 **Responsibility**: The API Unification Layer. It defines the abstract interface for interacting with any exchange.
 *   **Contents**: `trait`s (interfaces) like `MarketStream` (for subscribing to live data) and `ExecutionClient` (for placing orders and managing accounts). It contains **no concrete implementations**.
 *   **Rule**: If you are defining a behavior that an exchange must provide (e.g., "fetch open orders"), the trait for it belongs here.
+
+#### `tesser-events`
+**Responsibility**: Encapsulates every framework-level event type (ticks, candles, order-book deltas, signals, fills, order updates) plus the publish/subscribe bus used across the CLI, backtester, and future services.
+*   **Contents**: A `tokio::broadcast`-powered `EventBus` and typed wrappers (`TickEvent`, `SignalEvent`, etc.) that decouple producers from consumers.
+*   **Rule**: Emit and consume runtime activity via the bus instead of calling modules directly; this keeps the event flow extensible (risk daemons, telemetry sinks, notification services) without rewriting the core loop.
 
 ---
 

--- a/tesser-cli/Cargo.toml
+++ b/tesser-cli/Cargo.toml
@@ -26,6 +26,7 @@ tesser-backtester = { path = "../tesser-backtester" }
 tesser-config = { path = "../tesser-config" }
 tesser-core = { path = "../tesser-core" }
 tesser-data = { path = "../tesser-data" }
+tesser-events = { path = "../tesser-events" }
 tesser-execution = { path = "../tesser-execution" }
 tesser-portfolio = { path = "../tesser-portfolio" }
 tesser-strategy = { path = "../tesser-strategy" }

--- a/tesser-events/Cargo.toml
+++ b/tesser-events/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "tesser-events"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tesser-core = { path = "../tesser-core" }
+tokio = { version = "1", features = ["sync"] }
+serde = { version = "1", features = ["derive"] }

--- a/tesser-events/src/lib.rs
+++ b/tesser-events/src/lib.rs
@@ -1,0 +1,74 @@
+use serde::{Deserialize, Serialize};
+use tesser_core::{Candle, Fill, Order, OrderBook, Signal, Tick};
+use tokio::sync::broadcast;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TickEvent {
+    pub tick: Tick,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CandleEvent {
+    pub candle: Candle,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct OrderBookEvent {
+    pub order_book: OrderBook,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SignalEvent {
+    pub signal: Signal,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FillEvent {
+    pub fill: Fill,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct OrderUpdateEvent {
+    pub order: Order,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum Event {
+    Tick(TickEvent),
+    Candle(CandleEvent),
+    OrderBook(OrderBookEvent),
+    Signal(SignalEvent),
+    Fill(FillEvent),
+    OrderUpdate(OrderUpdateEvent),
+}
+
+pub struct EventBus {
+    sender: broadcast::Sender<Event>,
+}
+
+impl EventBus {
+    pub fn new(capacity: usize) -> Self {
+        let (sender, _) = broadcast::channel(capacity);
+        Self { sender }
+    }
+
+    pub fn subscribe(&self) -> EventStream {
+        EventStream {
+            receiver: self.sender.subscribe(),
+        }
+    }
+
+    pub fn publish(&self, event: Event) {
+        let _ = self.sender.send(event);
+    }
+}
+
+pub struct EventStream {
+    receiver: broadcast::Receiver<Event>,
+}
+
+impl EventStream {
+    pub async fn recv(&mut self) -> Result<Event, broadcast::error::RecvError> {
+        self.receiver.recv().await
+    }
+}

--- a/tesser-execution/src/orchestrator.rs
+++ b/tesser-execution/src/orchestrator.rs
@@ -33,6 +33,7 @@ struct StoredAlgoState {
 /// - Routing events (fills, ticks, timers) to appropriate algorithms
 /// - Persisting algorithm state for crash recovery
 /// - Handling the lifecycle of algorithmic orders
+#[derive(Clone)]
 pub struct OrderOrchestrator {
     /// Active algorithm instances.
     algorithms: Arc<Mutex<HashMap<Uuid, Box<dyn ExecutionAlgorithm>>>>,


### PR DESCRIPTION
## Summary
- Added the new `tesser-events` crate, defining typed events and a `tokio::broadcast`-powered `EventBus`.
- Refactored `tesser-cli` live runtime into a pub/sub architecture where ticks, candles, books, signals, fills, and order updates are published and consumed by dedicated async workers.
- Made `OrderOrchestrator` clonable and ensured risk context/persistence updates flow through shared helpers; updated README to describe the new event-bus crate.

## Testing
- `cargo clippy`
- `cargo test -p tesser-cli`
