### PR TITLE
visualization: candles query + Arrow decode + chart

### DIFF
--- a/visualization/app/package.json
+++ b/visualization/app/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "apache-arrow": "^14.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",

--- a/visualization/app/pnpm-lock.yaml
+++ b/visualization/app/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.5.3
+      apache-arrow:
+        specifier: ^14.0.2
+        version: 14.0.2
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -74,6 +77,10 @@ importers:
         version: 3.2.4(jiti@1.21.7)
 
 packages:
+
+  '@75lb/deep-merge@1.1.2':
+    resolution: {integrity: sha512-08K9ou5VNbheZFxM5tDWoqjA3ImC50DiuuJ2tj1yEPRfkp8lLLg6XAaJ4On+a0yAXor/8ay5gHnAIshRM44Kpw==}
+    engines: {node: '>=12.17'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -724,11 +731,23 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/command-line-args@5.2.0':
+    resolution: {integrity: sha512-UuKzKpJJ/Ief6ufIaIzr3A/0XnluX7RvFgwkV89Yzvm77wCh1kFaFmqN8XEnGcN62EuHdedQjEMb8mYxFLGPyA==}
+
+  '@types/command-line-usage@5.0.2':
+    resolution: {integrity: sha512-n7RlEEJ+4x4TS7ZQddTmNSxP+zziEG0TNsMfiRIxcIVXt71ENJ9ojeXmGO3wPoTdn7pJcU2xc3CJYMktNT6DPg==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node@20.3.0':
+    resolution: {integrity: sha512-cumHmIAf6On83X7yP+LrsEyUOf/YlociZelmpRYaGFydoaPdxdt80MAbu6vWerQT2COCp2nPvHdsbD7tHn/YlQ==}
+
+  '@types/pad-left@2.1.1':
+    resolution: {integrity: sha512-Xd22WCRBydkGSApl5Bw0PhAOHKSVjNL3E3AwzKaps96IMraPqy5BvZIsBVK6JLwdybUzjHnuWVwpDd0JjTfHXA==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -773,6 +792,10 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -780,8 +803,20 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  apache-arrow@14.0.2:
+    resolution: {integrity: sha512-EBO2xJN36/XoY81nhLcwCJgFwkboDZeyNQ+OPsG7bCoQjc2BT0aTyH/MR6SrL+LirSNz+cYqjGRlupMMlP1aEg==}
+    hasBin: true
+
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  array-back@3.1.0:
+    resolution: {integrity: sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==}
+    engines: {node: '>=6'}
+
+  array-back@6.2.2:
+    resolution: {integrity: sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==}
+    engines: {node: '>=12.17'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -827,6 +862,14 @@ packages:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
 
+  chalk-template@0.4.0:
+    resolution: {integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==}
+    engines: {node: '>=12'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
@@ -841,6 +884,21 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  command-line-args@5.2.1:
+    resolution: {integrity: sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==}
+    engines: {node: '>=4.0.0'}
+
+  command-line-usage@7.0.1:
+    resolution: {integrity: sha512-NCyznE//MuTjwi3y84QVUGEOT+P5oto1e1Pk/jFPVdPPfsG03qpTIl3yw6etR+v73d0lXsoojRpvbru2sqePxQ==}
+    engines: {node: '>=12.20.0'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -918,6 +976,13 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  find-replace@3.0.0:
+    resolution: {integrity: sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==}
+    engines: {node: '>=4.0.0'}
+
+  flatbuffers@23.5.26:
+    resolution: {integrity: sha512-vE+SI9vrJDwi1oETtTIFldC/o9GsVKRM+s6EL0nQgxXlYV1Vc4Tk30hj4xGICftInKQKj1F3up2n8UbIVobISQ==}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
@@ -940,6 +1005,10 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -980,6 +1049,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bignum@0.0.3:
+    resolution: {integrity: sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==}
+    engines: {node: '>=0.8'}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -991,6 +1064,12 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash@4.17.23:
+    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -1039,6 +1118,10 @@ packages:
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
+
+  pad-left@2.1.0:
+    resolution: {integrity: sha512-HJxs9K9AztdIQIAIa/OIazRAUW/L6B9hbQDxO4X07roW3eo9XqZc2ur9bn1StH9CnbbI9EgvejHQX7CBpCF1QA==}
+    engines: {node: '>=0.10.0'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -1139,6 +1222,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  repeat-string@1.6.1:
+    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
+    engines: {node: '>=0.10'}
+
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
@@ -1176,6 +1263,10 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stream-read-all@3.0.1:
+    resolution: {integrity: sha512-EWZT9XOceBPlVJRrYcykW8jyRSZYbkb/0ZK36uLEmoWVO5gxBOnntNTseNzfREsqxqdfEGQrD8SXQ3QWbBmq8A==}
+    engines: {node: '>=10'}
+
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
@@ -1184,9 +1275,18 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  table-layout@3.0.2:
+    resolution: {integrity: sha512-rpyNZYRw+/C+dYkcQ3Pr+rLxW4CfHpXjPDnG7lYhdRoUcZTUt+KEsX+94RGp/aVp/MQU35JCITv2T/beY4m+hw==}
+    engines: {node: '>=12.17'}
+    hasBin: true
 
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
@@ -1237,10 +1337,21 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  typical@4.0.0:
+    resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==}
+    engines: {node: '>=8'}
+
+  typical@7.3.0:
+    resolution: {integrity: sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==}
+    engines: {node: '>=12.17'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -1329,10 +1440,19 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wordwrapjs@5.1.1:
+    resolution: {integrity: sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==}
+    engines: {node: '>=12.17'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
 snapshots:
+
+  '@75lb/deep-merge@1.1.2':
+    dependencies:
+      lodash: 4.17.23
+      typical: 7.3.0
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -1845,9 +1965,17 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/command-line-args@5.2.0': {}
+
+  '@types/command-line-usage@5.0.2': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/node@20.3.0': {}
+
+  '@types/pad-left@2.1.1': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -1911,6 +2039,10 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   any-promise@1.3.0: {}
 
   anymatch@3.1.3:
@@ -1918,7 +2050,24 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  apache-arrow@14.0.2:
+    dependencies:
+      '@types/command-line-args': 5.2.0
+      '@types/command-line-usage': 5.0.2
+      '@types/node': 20.3.0
+      '@types/pad-left': 2.1.1
+      command-line-args: 5.2.1
+      command-line-usage: 7.0.1
+      flatbuffers: 23.5.26
+      json-bignum: 0.0.3
+      pad-left: 2.1.0
+      tslib: 2.8.1
+
   arg@5.0.2: {}
+
+  array-back@3.1.0: {}
+
+  array-back@6.2.2: {}
 
   assertion-error@2.0.1: {}
 
@@ -1961,6 +2110,15 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  chalk-template@0.4.0:
+    dependencies:
+      chalk: 4.1.2
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   check-error@2.1.3: {}
 
   chokidar@3.6.0:
@@ -1980,6 +2138,26 @@ snapshots:
       clsx: 2.1.1
 
   clsx@2.1.1: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  command-line-args@5.2.1:
+    dependencies:
+      array-back: 3.1.0
+      find-replace: 3.0.0
+      lodash.camelcase: 4.3.0
+      typical: 4.0.0
+
+  command-line-usage@7.0.1:
+    dependencies:
+      array-back: 6.2.2
+      chalk-template: 0.4.0
+      table-layout: 3.0.2
+      typical: 7.3.0
 
   commander@4.1.1: {}
 
@@ -2060,6 +2238,12 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  find-replace@3.0.0:
+    dependencies:
+      array-back: 3.1.0
+
+  flatbuffers@23.5.26: {}
+
   fraction.js@5.3.4: {}
 
   fsevents@2.3.3:
@@ -2076,6 +2260,8 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  has-flag@4.0.0: {}
 
   hasown@2.0.2:
     dependencies:
@@ -2105,11 +2291,17 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bignum@0.0.3: {}
+
   json5@2.2.3: {}
 
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
+
+  lodash.camelcase@4.3.0: {}
+
+  lodash@4.17.23: {}
 
   loupe@3.2.1: {}
 
@@ -2149,6 +2341,10 @@ snapshots:
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
+
+  pad-left@2.1.0:
+    dependencies:
+      repeat-string: 1.6.1
 
   path-parse@1.0.7: {}
 
@@ -2222,6 +2418,8 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  repeat-string@1.6.1: {}
+
   resolve@1.22.11:
     dependencies:
       is-core-module: 2.16.1
@@ -2277,6 +2475,8 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  stream-read-all@3.0.1: {}
+
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
@@ -2291,7 +2491,21 @@ snapshots:
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  table-layout@3.0.2:
+    dependencies:
+      '@75lb/deep-merge': 1.1.2
+      array-back: 6.2.2
+      command-line-args: 5.2.1
+      command-line-usage: 7.0.1
+      stream-read-all: 3.0.1
+      typical: 7.3.0
+      wordwrapjs: 5.1.1
 
   tailwind-merge@3.5.0: {}
 
@@ -2356,7 +2570,13 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  tslib@2.8.1: {}
+
   typescript@5.8.3: {}
+
+  typical@4.0.0: {}
+
+  typical@7.3.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -2442,5 +2662,7 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wordwrapjs@5.1.1: {}
 
   yallist@3.1.1: {}

--- a/visualization/app/src-tauri/src/candles.rs
+++ b/visualization/app/src-tauri/src/candles.rs
@@ -3,7 +3,7 @@
 use std::io::Cursor;
 use std::sync::Arc;
 
-use arrow_array::{Float64Array, Int64Array, RecordBatch};
+use arrow_array::{Array, Float64Array, Int64Array, RecordBatch};
 use arrow_ipc::reader::StreamReader;
 use arrow_ipc::writer::StreamWriter;
 use arrow_schema::{DataType, Field, Schema};
@@ -257,6 +257,8 @@ fn build_arrow_stream_bytes_ohlcv(
     close: &[f64],
     volume: &[f64],
 ) -> Result<Vec<u8>, String> {
+    const MAX_ROWS_PER_BATCH: usize = 2048;
+
     let schema = Schema::new(vec![
         Field::new("ts_ms", DataType::Int64, false),
         Field::new("open", DataType::Float64, false),
@@ -266,23 +268,36 @@ fn build_arrow_stream_bytes_ohlcv(
         Field::new("volume", DataType::Float64, false),
     ]);
 
-    let batch = RecordBatch::try_new(
-        Arc::new(schema.clone()),
-        vec![
-            Arc::new(Int64Array::from(ts.to_vec())),
-            Arc::new(Float64Array::from(open.to_vec())),
-            Arc::new(Float64Array::from(high.to_vec())),
-            Arc::new(Float64Array::from(low.to_vec())),
-            Arc::new(Float64Array::from(close.to_vec())),
-            Arc::new(Float64Array::from(volume.to_vec())),
-        ],
-    )
-    .map_err(|e| e.to_string())?;
+    let schema = Arc::new(schema);
+
+    let ts_arr: Arc<dyn arrow_array::Array> = Arc::new(Int64Array::from(ts.to_vec()));
+    let open_arr: Arc<dyn arrow_array::Array> = Arc::new(Float64Array::from(open.to_vec()));
+    let high_arr: Arc<dyn arrow_array::Array> = Arc::new(Float64Array::from(high.to_vec()));
+    let low_arr: Arc<dyn arrow_array::Array> = Arc::new(Float64Array::from(low.to_vec()));
+    let close_arr: Arc<dyn arrow_array::Array> = Arc::new(Float64Array::from(close.to_vec()));
+    let volume_arr: Arc<dyn arrow_array::Array> = Arc::new(Float64Array::from(volume.to_vec()));
 
     let mut out = Vec::new();
     {
         let mut writer = StreamWriter::try_new(&mut out, &schema).map_err(|e| e.to_string())?;
-        writer.write(&batch).map_err(|e| e.to_string())?;
+        let mut offset = 0usize;
+        while offset < ts.len() {
+            let len = (ts.len() - offset).min(MAX_ROWS_PER_BATCH);
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    ts_arr.slice(offset, len),
+                    open_arr.slice(offset, len),
+                    high_arr.slice(offset, len),
+                    low_arr.slice(offset, len),
+                    close_arr.slice(offset, len),
+                    volume_arr.slice(offset, len),
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+            writer.write(&batch).map_err(|e| e.to_string())?;
+            offset += len;
+        }
         writer.finish().map_err(|e| e.to_string())?;
     }
 
@@ -387,6 +402,11 @@ async fn candles_query_impl(
             TransportErrorPublic::Unavailable => CommandError::new(
                 "TRANSPORT.UNAVAILABLE",
                 "loopback_ws transport unavailable",
+                req.envelope.correlation_id.clone(),
+            ),
+            TransportErrorPublic::ResourceLimit { message } => CommandError::new(
+                "TRANSPORT.RESOURCE_LIMIT",
+                message,
                 req.envelope.correlation_id.clone(),
             ),
         })?;
@@ -588,6 +608,118 @@ mod tests {
             }
         }
         assert!(saw_alignment);
+        assert_eq!(rows as u32, resp.meta.points_returned);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn candles_query_large_result_streams_and_decodes() {
+        let transport = TransportState::default();
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let layout = StorageLayout {
+            workspace_root: tmp.path().join("ws"),
+            dataset_root: tmp.path().join("ds"),
+            cache_root: tmp.path().join("cache"),
+        };
+        layout.ensure().expect("ensure");
+
+        let dataset_id = "crypto.synthetic.spot.demo.series.1s.v1";
+        let preview = crate::datasets::create_synthetic_dataset(&layout, dataset_id).expect("ds");
+
+        let resp = candles_query_impl(
+            &transport,
+            &layout,
+            CandlesQueryRequest {
+                envelope: envelope("c_large"),
+                dataset_id: dataset_id.to_string(),
+                dataset_manifest_ref: Some(DatasetManifestRef {
+                    manifest_hash: preview.active_manifest_hash.clone().expect("hash"),
+                    uri: None,
+                }),
+                range: RangeMs {
+                    start_ms: 0,
+                    end_ms: (MAX_TARGET_POINTS as i64) * 1_000,
+                },
+                target_points: MAX_TARGET_POINTS,
+                prefer_tiles: Some(true),
+                allow_raw_fallback: Some(true),
+            },
+        )
+        .await
+        .expect("query");
+
+        assert!(resp.meta.points_returned <= MAX_TARGET_POINTS);
+        assert_eq!(resp.meta.correlation_id, "c_large");
+
+        let (ws_url, auth_token, stream_id) = match &resp.stream_ref.transport {
+            StreamTransport::LoopbackWs {
+                url, auth_token, ..
+            } => (
+                url.clone(),
+                auth_token.clone(),
+                resp.stream_ref.stream_id.clone(),
+            ),
+        };
+
+        let mut ws = ws_connect(&ws_url, &auth_token).await;
+
+        let mut combined = Vec::new();
+        let mut next_seq = 1u64;
+        loop {
+            ws.send(Message::Text(
+                serde_json::to_string(&serde_json::json!({
+                    "type": "streams.pull",
+                    "stream_id": stream_id,
+                    "next_seq": next_seq,
+                    "max_bytes": limits::MAX_BYTES_PER_PULL,
+                    "correlation_id": "c_large",
+                    "request_id": Uuid::new_v4().to_string()
+                }))
+                .expect("json"),
+            ))
+            .await
+            .expect("send pull");
+
+            let msg = timeout(std::time::Duration::from_secs(2), ws.next())
+                .await
+                .expect("timeout")
+                .expect("stream ended")
+                .expect("ws msg");
+
+            match msg {
+                Message::Binary(frame) => {
+                    let (kind, seq, _sid, payload) = parse_frame(&frame);
+                    assert_eq!(seq, next_seq);
+                    if kind == 1 {
+                        combined.extend_from_slice(&payload);
+                        next_seq += 1;
+                        continue;
+                    }
+                    if kind == 2 {
+                        assert!(payload.is_empty());
+                        break;
+                    }
+                    panic!("unexpected frame kind: {kind}");
+                }
+                other => panic!("unexpected ws msg: {other:?}"),
+            }
+        }
+
+        let msg = timeout(std::time::Duration::from_secs(2), ws.next())
+            .await
+            .expect("timeout")
+            .expect("stream ended")
+            .expect("ws msg");
+        let Message::Text(text) = msg else {
+            panic!("expected streams.closed");
+        };
+        let v: serde_json::Value = serde_json::from_str(&text).expect("json");
+        assert_eq!(v["type"], "streams.closed");
+
+        let mut reader = StreamReader::try_new(Cursor::new(combined), None).expect("arrow reader");
+        let mut rows = 0usize;
+        while let Some(batch) = reader.next().transpose().expect("read batch") {
+            rows += batch.num_rows();
+        }
         assert_eq!(rows as u32, resp.meta.points_returned);
     }
 

--- a/visualization/app/src-tauri/src/series.rs
+++ b/visualization/app/src-tauri/src/series.rs
@@ -2,7 +2,7 @@
 
 use std::io::Cursor;
 
-use arrow_array::{Float64Array, Int64Array, RecordBatch};
+use arrow_array::{Array, Float64Array, Int64Array, RecordBatch};
 use arrow_ipc::reader::StreamReader;
 use arrow_ipc::writer::StreamWriter;
 use arrow_schema::{DataType, Field, Schema};
@@ -53,24 +53,33 @@ pub struct SeriesQueryResponse {
 }
 
 fn build_arrow_stream_bytes_last(ts: &[i64], value: &[f64]) -> Result<Vec<u8>, String> {
+    const MAX_ROWS_PER_BATCH: usize = 4096;
+
     let schema = Schema::new(vec![
         Field::new("ts_ms", DataType::Int64, false),
         Field::new("value", DataType::Float64, false),
     ]);
 
-    let batch = RecordBatch::try_new(
-        schema.clone().into(),
-        vec![
-            std::sync::Arc::new(Int64Array::from(ts.to_vec())),
-            std::sync::Arc::new(Float64Array::from(value.to_vec())),
-        ],
-    )
-    .map_err(|e| e.to_string())?;
+    let schema = std::sync::Arc::new(schema);
+    let ts_arr: std::sync::Arc<dyn arrow_array::Array> =
+        std::sync::Arc::new(Int64Array::from(ts.to_vec()));
+    let value_arr: std::sync::Arc<dyn arrow_array::Array> =
+        std::sync::Arc::new(Float64Array::from(value.to_vec()));
 
     let mut out = Vec::new();
     {
         let mut writer = StreamWriter::try_new(&mut out, &schema).map_err(|e| e.to_string())?;
-        writer.write(&batch).map_err(|e| e.to_string())?;
+        let mut offset = 0usize;
+        while offset < ts.len() {
+            let len = (ts.len() - offset).min(MAX_ROWS_PER_BATCH);
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![ts_arr.slice(offset, len), value_arr.slice(offset, len)],
+            )
+            .map_err(|e| e.to_string())?;
+            writer.write(&batch).map_err(|e| e.to_string())?;
+            offset += len;
+        }
         writer.finish().map_err(|e| e.to_string())?;
     }
 
@@ -90,6 +99,8 @@ fn build_arrow_stream_bytes_minmax(
     max_value: &[f64],
     last_value: &[f64],
 ) -> Result<Vec<u8>, String> {
+    const MAX_ROWS_PER_BATCH: usize = 4096;
+
     let schema = Schema::new(vec![
         Field::new("ts_ms", DataType::Int64, false),
         Field::new("min_value", DataType::Float64, false),
@@ -97,21 +108,35 @@ fn build_arrow_stream_bytes_minmax(
         Field::new("last_value", DataType::Float64, false),
     ]);
 
-    let batch = RecordBatch::try_new(
-        schema.clone().into(),
-        vec![
-            std::sync::Arc::new(Int64Array::from(ts.to_vec())),
-            std::sync::Arc::new(Float64Array::from(min_value.to_vec())),
-            std::sync::Arc::new(Float64Array::from(max_value.to_vec())),
-            std::sync::Arc::new(Float64Array::from(last_value.to_vec())),
-        ],
-    )
-    .map_err(|e| e.to_string())?;
+    let schema = std::sync::Arc::new(schema);
+    let ts_arr: std::sync::Arc<dyn arrow_array::Array> =
+        std::sync::Arc::new(Int64Array::from(ts.to_vec()));
+    let min_arr: std::sync::Arc<dyn arrow_array::Array> =
+        std::sync::Arc::new(Float64Array::from(min_value.to_vec()));
+    let max_arr: std::sync::Arc<dyn arrow_array::Array> =
+        std::sync::Arc::new(Float64Array::from(max_value.to_vec()));
+    let last_arr: std::sync::Arc<dyn arrow_array::Array> =
+        std::sync::Arc::new(Float64Array::from(last_value.to_vec()));
 
     let mut out = Vec::new();
     {
         let mut writer = StreamWriter::try_new(&mut out, &schema).map_err(|e| e.to_string())?;
-        writer.write(&batch).map_err(|e| e.to_string())?;
+        let mut offset = 0usize;
+        while offset < ts.len() {
+            let len = (ts.len() - offset).min(MAX_ROWS_PER_BATCH);
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    ts_arr.slice(offset, len),
+                    min_arr.slice(offset, len),
+                    max_arr.slice(offset, len),
+                    last_arr.slice(offset, len),
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+            writer.write(&batch).map_err(|e| e.to_string())?;
+            offset += len;
+        }
         writer.finish().map_err(|e| e.to_string())?;
     }
 
@@ -365,6 +390,11 @@ async fn series_query_impl(
             TransportErrorPublic::Unavailable => CommandError::new(
                 "TRANSPORT.UNAVAILABLE",
                 "loopback_ws transport unavailable",
+                req.envelope.correlation_id.clone(),
+            ),
+            TransportErrorPublic::ResourceLimit { message } => CommandError::new(
+                "TRANSPORT.RESOURCE_LIMIT",
+                message,
                 req.envelope.correlation_id.clone(),
             ),
         })?;

--- a/visualization/app/src-tauri/src/transport.rs
+++ b/visualization/app/src-tauri/src/transport.rs
@@ -27,6 +27,7 @@ enum TransportError {
 #[derive(Debug, Clone)]
 pub enum TransportErrorPublic {
     Unavailable,
+    ResourceLimit { message: String },
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -46,6 +47,10 @@ pub struct DemoStreamRef {
 pub struct TransportState {
     inner: Mutex<TransportInner>,
 }
+
+const MAX_PENDING_STREAMS: usize = 32;
+const MAX_PENDING_BYTES_PER_STREAM: usize = 64 * 1024 * 1024;
+const MAX_PENDING_BYTES_TOTAL: usize = 256 * 1024 * 1024;
 
 struct TransportInner {
     ws_url: Option<String>,
@@ -88,6 +93,15 @@ impl TransportState {
         let auth_token = new_auth_token_hex();
         let expires_at_ms = now_ms() + 60_000;
 
+        let bytes_total: usize = chunks.iter().map(|c| c.len()).sum();
+        if bytes_total > MAX_PENDING_BYTES_PER_STREAM {
+            return Err(TransportErrorPublic::ResourceLimit {
+                message: format!(
+                    "pending stream too large: bytes_total={bytes_total} max={MAX_PENDING_BYTES_PER_STREAM}"
+                ),
+            });
+        }
+
         let stream = DemoStream {
             stream_id,
             expected_next_seq: limits::STREAM_SEQ_START,
@@ -101,13 +115,32 @@ impl TransportState {
                 .registry
                 .lock()
                 .map_err(|_| TransportErrorPublic::Unavailable)?;
+            reg.retain_unexpired(now_ms());
+            if reg.pending_by_token.len() >= MAX_PENDING_STREAMS {
+                return Err(TransportErrorPublic::ResourceLimit {
+                    message: format!(
+                        "too many pending streams: {} (max {MAX_PENDING_STREAMS})",
+                        reg.pending_by_token.len()
+                    ),
+                });
+            }
+            if reg.pending_bytes_total.saturating_add(bytes_total) > MAX_PENDING_BYTES_TOTAL {
+                return Err(TransportErrorPublic::ResourceLimit {
+                    message: format!(
+                        "pending bytes budget exceeded: total={} add={bytes_total} max={MAX_PENDING_BYTES_TOTAL}",
+                        reg.pending_bytes_total
+                    ),
+                });
+            }
             reg.pending_by_token.insert(
                 auth_token.clone(),
                 PendingStream {
                     stream,
                     expires_at_ms,
+                    bytes_total,
                 },
             );
+            reg.pending_bytes_total = reg.pending_bytes_total.saturating_add(bytes_total);
         }
 
         Ok(StreamRef {
@@ -129,14 +162,17 @@ impl TransportState {
         let stream_id = Uuid::new_v4();
         let auth_token = new_auth_token_hex();
 
+        let chunks = vec![
+            b"DEMO:chunk-1\n".to_vec(),
+            b"DEMO:chunk-2\n".to_vec(),
+            b"DEMO:chunk-3\n".to_vec(),
+        ];
+        let bytes_total: usize = chunks.iter().map(|c| c.len()).sum();
+
         let demo = DemoStream {
             stream_id,
             expected_next_seq: limits::STREAM_SEQ_START,
-            chunks: vec![
-                b"DEMO:chunk-1\n".to_vec(),
-                b"DEMO:chunk-2\n".to_vec(),
-                b"DEMO:chunk-3\n".to_vec(),
-            ],
+            chunks,
             terminal_sent: false,
         };
 
@@ -148,13 +184,16 @@ impl TransportState {
                 .registry
                 .lock()
                 .map_err(|_| TransportError::Unauthorized)?;
+            reg.retain_unexpired(now_ms());
             reg.pending_by_token.insert(
                 auth_token.clone(),
                 PendingStream {
                     stream: demo,
                     expires_at_ms,
+                    bytes_total,
                 },
             );
+            reg.pending_bytes_total = reg.pending_bytes_total.saturating_add(bytes_total);
         }
 
         Ok(DemoStreamRef {
@@ -179,11 +218,13 @@ impl TransportState {
 #[derive(Default)]
 struct StreamRegistry {
     pending_by_token: HashMap<String, PendingStream>,
+    pending_bytes_total: usize,
 }
 
 struct PendingStream {
     stream: DemoStream,
     expires_at_ms: u64,
+    bytes_total: usize,
 }
 
 struct DemoStream {
@@ -241,6 +282,31 @@ fn now_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or(Duration::from_secs(0))
         .as_millis() as u64
+}
+
+impl StreamRegistry {
+    fn retain_unexpired(&mut self, now_ms: u64) {
+        let mut removed_bytes = 0usize;
+        self.pending_by_token.retain(|_, pending| {
+            let keep = pending.expires_at_ms > now_ms;
+            if !keep {
+                removed_bytes = removed_bytes.saturating_add(pending.bytes_total);
+            }
+            keep
+        });
+        self.pending_bytes_total = self.pending_bytes_total.saturating_sub(removed_bytes);
+    }
+
+    fn take_pending(&mut self, token: &str) -> Option<PendingStream> {
+        let pending = self.pending_by_token.remove(token)?;
+        self.pending_bytes_total = self.pending_bytes_total.saturating_sub(pending.bytes_total);
+        Some(pending)
+    }
+
+    fn insert_pending(&mut self, token: String, pending: PendingStream) {
+        self.pending_bytes_total = self.pending_bytes_total.saturating_add(pending.bytes_total);
+        self.pending_by_token.insert(token, pending);
+    }
 }
 
 fn new_auth_token_hex() -> String {
@@ -312,7 +378,7 @@ async fn ensure_transport_started(state: &TransportState) -> Result<String, Tran
                 _ = tick.tick() => {
                     let now = now_ms();
                     if let Ok(mut reg) = registry.lock() {
-                        reg.pending_by_token.retain(|_, pending| pending.expires_at_ms > now);
+                        reg.retain_unexpired(now);
                         if reg.pending_by_token.is_empty()
                             && active_connections.load(Ordering::SeqCst) == 0
                         {
@@ -402,12 +468,10 @@ async fn handle_ws_connection(
             let mut registry_guard = registry_cb
                 .lock()
                 .map_err(|_| error_response(StatusCode::UNAUTHORIZED))?;
-            registry_guard
-                .pending_by_token
-                .retain(|_, pending| pending.expires_at_ms > now);
+            registry_guard.retain_unexpired(now);
 
             for token in candidates {
-                let Some(pending) = registry_guard.pending_by_token.remove(&token) else {
+                let Some(pending) = registry_guard.take_pending(&token) else {
                     continue;
                 };
                 if pending.expires_at_ms <= now {
@@ -417,7 +481,7 @@ async fn handle_ws_connection(
                 let prev = active_cb.fetch_add(1, Ordering::SeqCst);
                 if prev >= limits::MAX_ACTIVE_STREAMS {
                     active_cb.fetch_sub(1, Ordering::SeqCst);
-                    registry_guard.pending_by_token.insert(token, pending);
+                    registry_guard.insert_pending(token, pending);
                     return Err(error_response(StatusCode::TOO_MANY_REQUESTS));
                 }
                 reserved_slot_cb.store(true, Ordering::SeqCst);

--- a/visualization/app/src/App.tsx
+++ b/visualization/app/src/App.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { pullLoopbackWsStream, type WsLike } from "@/lib/streaming/loopback_ws";
+import { CandlesPanel } from "@/components/candles/CandlesPanel";
 
 type ProtocolInfo = {
   protocol_version: string;
@@ -155,6 +156,7 @@ function App() {
         <Tabs defaultValue="runs" className="flex-1">
           <TabsList>
             <TabsTrigger value="runs">Runs</TabsTrigger>
+            <TabsTrigger value="candles">Candles</TabsTrigger>
             <TabsTrigger value="datasets">Datasets</TabsTrigger>
             <TabsTrigger value="compare">Compare</TabsTrigger>
             <TabsTrigger value="downloads">Downloads</TabsTrigger>
@@ -195,6 +197,10 @@ function App() {
                 Coming soon: dataset manifests, health checks, and imports.
               </CardContent>
             </Card>
+          </TabsContent>
+
+          <TabsContent value="candles" className="mt-4">
+            <CandlesPanel />
           </TabsContent>
 
           <TabsContent value="compare" className="mt-4">

--- a/visualization/app/src/components/candles/CandlesCanvas.tsx
+++ b/visualization/app/src/components/candles/CandlesCanvas.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useMemo, useRef } from "react";
+import type { CandlesOhlcv } from "@/lib/candles/schema";
+
+type Props = {
+  candles: CandlesOhlcv | null;
+};
+
+function finiteMinMax(values: Float64Array): { min: number; max: number } {
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (let i = 0; i < values.length; i++) {
+    const v = values[i];
+    if (!Number.isFinite(v)) continue;
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return { min: 0, max: 1 };
+  if (min === max) return { min: min - 1, max: max + 1 };
+  return { min, max };
+}
+
+export function CandlesCanvas({ candles }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const stats = useMemo(() => {
+    if (!candles || candles.ts_ms.length === 0) return null;
+    const { min, max } = finiteMinMax(candles.high);
+    const { min: minLow } = finiteMinMax(candles.low);
+    return { min: Math.min(minLow, min), max };
+  }, [candles]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const cssWidth = canvas.clientWidth;
+    const cssHeight = canvas.clientHeight;
+    canvas.width = Math.max(1, Math.floor(cssWidth * dpr));
+    canvas.height = Math.max(1, Math.floor(cssHeight * dpr));
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    ctx.clearRect(0, 0, cssWidth, cssHeight);
+
+    if (!candles || candles.ts_ms.length === 0 || !stats) {
+      ctx.fillStyle = "rgba(148,163,184,0.8)";
+      ctx.font = "12px ui-sans-serif, system-ui";
+      ctx.fillText("No candles loaded", 8, 18);
+      return;
+    }
+
+    const { min, max } = stats;
+    const padX = 8;
+    const padY = 8;
+    const w = cssWidth - padX * 2;
+    const h = cssHeight - padY * 2;
+    const n = candles.ts_ms.length;
+    const pxPerCandle = w / Math.max(1, n);
+    const bodyWidth = Math.max(1, Math.min(8, pxPerCandle * 0.6));
+
+    const yOf = (price: number) => {
+      const t = (price - min) / (max - min);
+      return padY + h * (1 - t);
+    };
+
+    ctx.lineWidth = 1;
+    for (let i = 0; i < n; i++) {
+      const o = candles.open[i];
+      const c = candles.close[i];
+      const hi = candles.high[i];
+      const lo = candles.low[i];
+
+      const xCenter = padX + (i + 0.5) * pxPerCandle;
+      const x0 = xCenter - bodyWidth / 2;
+
+      const yOpen = yOf(o);
+      const yClose = yOf(c);
+      const yHigh = yOf(hi);
+      const yLow = yOf(lo);
+
+      const up = c >= o;
+      const bodyTop = Math.min(yOpen, yClose);
+      const bodyBottom = Math.max(yOpen, yClose);
+
+      ctx.strokeStyle = up ? "rgb(34,197,94)" : "rgb(239,68,68)";
+      ctx.fillStyle = up ? "rgba(34,197,94,0.25)" : "rgba(239,68,68,0.25)";
+
+      // Wick
+      ctx.beginPath();
+      ctx.moveTo(xCenter, yHigh);
+      ctx.lineTo(xCenter, yLow);
+      ctx.stroke();
+
+      // Body
+      const bodyHeight = Math.max(1, bodyBottom - bodyTop);
+      ctx.fillRect(x0, bodyTop, bodyWidth, bodyHeight);
+      ctx.strokeRect(x0, bodyTop, bodyWidth, bodyHeight);
+    }
+  }, [candles, stats]);
+
+  return <canvas ref={canvasRef} className="h-64 w-full rounded-md border bg-background" />;
+}
+

--- a/visualization/app/src/components/candles/CandlesPanel.tsx
+++ b/visualization/app/src/components/candles/CandlesPanel.tsx
@@ -1,0 +1,165 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CandlesCanvas } from "@/components/candles/CandlesCanvas";
+import { makeEnvelope } from "@/lib/tauri/envelope";
+import { createBrowserWebSocket } from "@/lib/tauri/websocket";
+import { candlesQueryAndDecode, type CandlesQueryMeta } from "@/lib/candles/client";
+import type { CandlesOhlcv } from "@/lib/candles/schema";
+
+type DatasetPreview = {
+  dataset_id: string;
+  time_range?: { start_ms: number; end_ms: number } | null;
+};
+
+type ProtocolInfo = { protocol_version: string };
+
+export function CandlesPanel() {
+  const [protocolVersion, setProtocolVersion] = useState<string | null>(null);
+  const [datasets, setDatasets] = useState<DatasetPreview[]>([]);
+  const [selected, setSelected] = useState<string>("");
+  const [loading, setLoading] = useState(false);
+  const [meta, setMeta] = useState<CandlesQueryMeta | null>(null);
+  const [candles, setCandles] = useState<CandlesOhlcv | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const info = await invoke<ProtocolInfo>("protocol_get_info");
+        setProtocolVersion(info.protocol_version);
+      } catch (e) {
+        setError(String(e));
+      }
+    })();
+  }, []);
+
+  const selectedPreview = useMemo(
+    () => datasets.find((d) => d.dataset_id === selected) ?? null,
+    [datasets, selected],
+  );
+
+  async function refreshDatasets() {
+    if (!protocolVersion) return;
+    setError(null);
+    const envelope = makeEnvelope({ protocolVersion, correlationId: "ui.datasets.list" });
+    const list = await invoke<DatasetPreview[]>("datasets_list", { req: { envelope } });
+    setDatasets(list);
+    if (!selected && list.length > 0) setSelected(list[0].dataset_id);
+  }
+
+  async function createSynthetic() {
+    if (!protocolVersion) return;
+    setError(null);
+    const dataset_id = "crypto.synthetic.spot.demo.series.1s.v1";
+    const envelope = makeEnvelope({ protocolVersion, correlationId: "ui.datasets.create" });
+    await invoke("datasets_create_synthetic", { req: { envelope, dataset_id } });
+    await refreshDatasets();
+    setSelected(dataset_id);
+  }
+
+  async function loadCandles() {
+    if (!protocolVersion) return;
+    if (!selected) return;
+
+    setLoading(true);
+    setError(null);
+    setMeta(null);
+    setCandles(null);
+
+    try {
+      const correlationId = "ui.candles.query";
+      const envelope = makeEnvelope({ protocolVersion, correlationId });
+
+      const timeRange = selectedPreview?.time_range ?? null;
+      const range = timeRange
+        ? { start_ms: timeRange.start_ms, end_ms: timeRange.end_ms }
+        : { start_ms: 0, end_ms: 86_400_000 };
+
+      const target_points = Math.max(
+        64,
+        Math.ceil(window.innerWidth * (window.devicePixelRatio || 1)),
+      );
+
+      const out = await candlesQueryAndDecode({
+        invoke,
+        createWs: createBrowserWebSocket,
+        req: {
+          envelope,
+          dataset_id: selected,
+          range,
+          target_points,
+          prefer_tiles: true,
+          allow_raw_fallback: true,
+        },
+      });
+
+      setMeta(out.meta);
+      setCandles(out.candles);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!protocolVersion) return;
+    refreshDatasets().catch((e) => setError(String(e)));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [protocolVersion]);
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <span>Candles</span>
+            <div className="flex gap-2">
+              <Button variant="secondary" onClick={() => refreshDatasets()} disabled={!protocolVersion}>
+                Refresh
+              </Button>
+              <Button variant="outline" onClick={() => createSynthetic()} disabled={!protocolVersion}>
+                Create Synthetic Dataset
+              </Button>
+              <Button onClick={() => loadCandles()} disabled={!protocolVersion || !selected || loading}>
+                {loading ? "Loading…" : "Load"}
+              </Button>
+            </div>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          {error ? <div className="rounded-md border p-2 text-destructive">{error}</div> : null}
+
+          <div className="grid gap-2 md:grid-cols-2">
+            <label className="space-y-1">
+              <div className="text-muted-foreground">dataset_id</div>
+              <select
+                className="w-full rounded-md border bg-background p-2"
+                value={selected}
+                onChange={(e) => setSelected(e.target.value)}
+              >
+                {datasets.map((d) => (
+                  <option key={d.dataset_id} value={d.dataset_id}>
+                    {d.dataset_id}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <div className="space-y-1">
+              <div className="text-muted-foreground">meta</div>
+              <div className="rounded-md border p-2 font-mono text-xs whitespace-pre-wrap">
+                {meta ? JSON.stringify(meta, null, 2) : "—"}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <CandlesCanvas candles={candles} />
+    </div>
+  );
+}
+

--- a/visualization/app/src/lib/arrow/ipc.ts
+++ b/visualization/app/src/lib/arrow/ipc.ts
@@ -1,0 +1,5 @@
+import { tableFromIPC, type Table } from "apache-arrow";
+
+export function decodeArrowIpcStream(bytes: Uint8Array): Table {
+  return tableFromIPC(bytes);
+}

--- a/visualization/app/src/lib/candles/client.test.ts
+++ b/visualization/app/src/lib/candles/client.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { pullLoopbackWsStream, type WsCloseEvent, type WsLike, type WsMessageEvent } from "./loopback_ws";
+import { tableFromArrays, tableToIPC } from "apache-arrow";
+
+import { candlesQueryAndDecode } from "./client";
+import type { WsCloseEvent, WsLike, WsMessageEvent } from "@/lib/streaming/loopback_ws";
 
 function uuidToBytes(uuid: string): Uint8Array {
   const hex = uuid.replace(/-/g, "");
@@ -12,7 +15,7 @@ function uuidToBytes(uuid: string): Uint8Array {
   return out;
 }
 
-function makeFrame(args: {
+function makeTsr1Frame(args: {
   kind: 1 | 2;
   seq: bigint;
   streamId: string;
@@ -34,6 +37,7 @@ function makeFrame(args: {
 class FakeWs implements WsLike {
   readyState = 0;
   sent: string[] = [];
+
   private listeners = {
     open: new Set<() => void>(),
     message: new Set<(ev: WsMessageEvent) => void>(),
@@ -110,37 +114,87 @@ class FakeWs implements WsLike {
   }
 }
 
-describe("pullLoopbackWsStream", () => {
-  it("pulls chunks then eof then closed without races", async () => {
-    const ws = new FakeWs();
+describe("candlesQueryAndDecode", () => {
+  it("pulls Arrow IPC bytes and decodes ohlcv columns", async () => {
     const streamId = "00112233-4455-6677-8899-aabbccddeeff";
 
-    const p = pullLoopbackWsStream({
-      ws,
-      streamId,
-      correlationId: "c1",
-      maxBytes: 256 * 1024,
-      requestId: "r1",
+    const table = tableFromArrays({
+      ts_ms: new BigInt64Array([0n, 1000n]),
+      open: new Float64Array([1, 2]),
+      high: new Float64Array([2, 3]),
+      low: new Float64Array([0.5, 1.5]),
+      close: new Float64Array([1.2, 1.8]),
+      volume: new Float64Array([10, 20]),
+    });
+    const arrowBytes = tableToIPC(table);
+
+    const ws = new FakeWs();
+    const createWs = () => ws;
+
+    const invoke = async (cmd: string): Promise<any> => {
+      expect(cmd).toBe("candles_query");
+      return {
+        meta: {
+          correlation_id: "c1",
+          manifest_hash: "m1",
+          lod_profile: "candles_ohlcv_v1",
+          lod_level: 0,
+          bucket_ms: 1000,
+          points_returned: 2,
+          data_source: "raw_fallback",
+          cache: "miss",
+        },
+        stream_ref: {
+          stream_id: streamId,
+          format: "arrow_ipc_stream",
+          schema_id: "candles.ohlcv.f64.v1",
+          transport: {
+            kind: "loopback_ws",
+            url: "ws://127.0.0.1:1",
+            auth_token: "token",
+            token_in: "sec-websocket-protocol",
+            expires_at_ms: 9999999999999,
+          },
+        },
+      };
+    };
+
+    const p = candlesQueryAndDecode({
+      invoke,
+      createWs,
+      req: {
+        envelope: {
+          protocol_version: "tesser.viz.ipc.v1",
+          correlation_id: "c1",
+          request_id: "r1",
+        },
+        dataset_id: "ds1",
+        range: { start_ms: 0, end_ms: 2000 },
+        target_points: 100,
+      },
     });
 
     ws.open();
 
-    // First pull request.
+    // First pull -> chunk
     await new Promise((r) => setTimeout(r, 0));
-    expect(ws.sent.length).toBe(1);
+    const pull1 = JSON.parse(ws.sent[0]) as { type: string; next_seq: number };
+    expect(pull1.type).toBe("streams.pull");
+    expect(pull1.next_seq).toBe(1);
     ws.emitMessage(
-      makeFrame({
+      makeTsr1Frame({
         kind: 1,
         seq: 1n,
         streamId,
-        payload: new TextEncoder().encode("abc"),
+        payload: new Uint8Array(arrowBytes),
       }),
     );
 
-    // Second pull request.
+    // Second pull -> eof + closed
     await new Promise((r) => setTimeout(r, 0));
-    expect(ws.sent.length).toBe(2);
-    ws.emitMessage(makeFrame({ kind: 2, seq: 2n, streamId }));
+    const pull2 = JSON.parse(ws.sent[1]) as { type: string; next_seq: number };
+    expect(pull2.next_seq).toBe(2);
+    ws.emitMessage(makeTsr1Frame({ kind: 2, seq: 2n, streamId }));
     ws.emitMessage(
       JSON.stringify({
         type: "streams.closed",
@@ -151,32 +205,14 @@ describe("pullLoopbackWsStream", () => {
     );
 
     const out = await p;
-    expect(new TextDecoder().decode(out.bytes)).toBe("abc");
-    expect(out.eofSeq).toBe(2n);
-  });
-
-  it("sends streams.cancel on abort", async () => {
-    const ws = new FakeWs();
-    const streamId = "00112233-4455-6677-8899-aabbccddeeff";
-    const ac = new AbortController();
-
-    const p = pullLoopbackWsStream({
-      ws,
-      streamId,
-      correlationId: "c_abort",
-      maxBytes: 256 * 1024,
-      requestId: "r_abort",
-      signal: ac.signal,
-      collectBytes: false,
-    });
-    void p.catch(() => {});
-
-    ws.open();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(ws.sent.length).toBe(1);
-    ac.abort();
-    await new Promise((r) => setTimeout(r, 0));
-    expect(ws.sent.some((s) => JSON.parse(s).type === "streams.cancel")).toBe(true);
-    await expect(p).rejects.toMatchObject({ name: "AbortError" });
+    expect(out.meta.points_returned).toBe(2);
+    expect(out.candles.ts_ms[0]).toBe(0);
+    expect(out.candles.ts_ms[1]).toBe(1000);
+    expect(out.candles.open[1]).toBe(2);
+    expect(out.candles.high[0]).toBe(2);
+    expect(out.candles.low[0]).toBe(0.5);
+    expect(out.candles.close[0]).toBe(1.2);
+    expect(out.candles.volume[1]).toBe(20);
   });
 });
+

--- a/visualization/app/src/lib/candles/client.ts
+++ b/visualization/app/src/lib/candles/client.ts
@@ -1,0 +1,96 @@
+import type { StreamRef, StreamTransportLoopbackWs, WsLike } from "@/lib/streaming/loopback_ws";
+import { pullLoopbackWsStream } from "@/lib/streaming/loopback_ws";
+import { decodeArrowIpcStream } from "@/lib/arrow/ipc";
+import { decodeCandlesOhlcvF64V1, type CandlesOhlcv } from "@/lib/candles/schema";
+
+export type RequestEnvelope = {
+  protocol_version: string;
+  correlation_id: string;
+  request_id: string;
+};
+
+export type RangeMs = {
+  start_ms: number;
+  end_ms: number;
+};
+
+export type CandlesQueryRequest = {
+  envelope: RequestEnvelope;
+  dataset_id: string;
+  range: RangeMs;
+  target_points: number;
+  prefer_tiles?: boolean;
+  allow_raw_fallback?: boolean;
+};
+
+export type CandlesQueryMeta = {
+  correlation_id: string;
+  manifest_hash: string;
+  lod_profile: string;
+  lod_level: number;
+  bucket_ms: number;
+  points_returned: number;
+  data_source: string;
+  cache: string;
+};
+
+export type CandlesQueryResponse = {
+  meta: CandlesQueryMeta;
+  stream_ref: StreamRef;
+};
+
+export type InvokeFn = <T>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
+export type CreateWsFn = (args: { url: string; authToken: string; tokenIn: string }) => WsLike;
+
+export async function candlesQueryAndDecode(args: {
+  invoke: InvokeFn;
+  createWs: CreateWsFn;
+  req: CandlesQueryRequest;
+  maxBytes?: number;
+  signal?: AbortSignal;
+}): Promise<{ meta: CandlesQueryMeta; candles: CandlesOhlcv }> {
+  const { invoke, req, createWs, signal } = args;
+  const maxBytes = args.maxBytes ?? 256 * 1024;
+
+  const resp = await invoke<CandlesQueryResponse>("candles_query", { req });
+
+  if (resp.stream_ref.format !== "arrow_ipc_stream") {
+    throw new Error(`unsupported stream format: ${resp.stream_ref.format}`);
+  }
+
+  if (resp.stream_ref.schema_id !== "candles.ohlcv.f64.v1") {
+    throw new Error(`unsupported schema_id: ${resp.stream_ref.schema_id ?? "null"}`);
+  }
+
+  const transport = resp.stream_ref.transport as StreamTransportLoopbackWs;
+  if (transport.kind !== "loopback_ws") throw new Error("unsupported transport kind");
+  if (transport.token_in !== "sec-websocket-protocol") {
+    throw new Error(`unsupported token_in: ${transport.token_in}`);
+  }
+
+  const ws = createWs({
+    url: transport.url,
+    authToken: transport.auth_token,
+    tokenIn: transport.token_in,
+  });
+
+  try {
+    const { bytes } = await pullLoopbackWsStream({
+      ws,
+      streamId: resp.stream_ref.stream_id,
+      correlationId: req.envelope.correlation_id,
+      requestId: req.envelope.request_id,
+      maxBytes,
+      signal,
+      maxTotalBytes: 64 * 1024 * 1024,
+      collectBytes: true,
+    });
+
+    const table = decodeArrowIpcStream(bytes);
+    const candles = decodeCandlesOhlcvF64V1(table);
+    return { meta: resp.meta, candles };
+  } finally {
+    ws.close();
+  }
+}
+

--- a/visualization/app/src/lib/candles/schema.ts
+++ b/visualization/app/src/lib/candles/schema.ts
@@ -1,0 +1,60 @@
+import type { Table } from "apache-arrow";
+
+export type CandlesOhlcv = {
+  ts_ms: Float64Array;
+  open: Float64Array;
+  high: Float64Array;
+  low: Float64Array;
+  close: Float64Array;
+  volume: Float64Array;
+};
+
+function getColumn(table: Table, name: string) {
+  const col = table.getChild(name);
+  if (!col) throw new Error(`missing column: ${name}`);
+  return col;
+}
+
+export function decodeCandlesOhlcvF64V1(table: Table): CandlesOhlcv {
+  const tsCol = getColumn(table, "ts_ms");
+  const openCol = getColumn(table, "open");
+  const highCol = getColumn(table, "high");
+  const lowCol = getColumn(table, "low");
+  const closeCol = getColumn(table, "close");
+  const volumeCol = getColumn(table, "volume");
+
+  const n = table.numRows;
+  const ts_ms = new Float64Array(n);
+  const open = new Float64Array(n);
+  const high = new Float64Array(n);
+  const low = new Float64Array(n);
+  const close = new Float64Array(n);
+  const volume = new Float64Array(n);
+
+  for (let i = 0; i < n; i++) {
+    const ts = tsCol.get(i);
+    if (typeof ts === "bigint") ts_ms[i] = Number(ts);
+    else if (typeof ts === "number") ts_ms[i] = ts;
+    else throw new Error(`unexpected ts_ms type at row ${i}`);
+
+    const o = openCol.get(i);
+    const h = highCol.get(i);
+    const l = lowCol.get(i);
+    const c = closeCol.get(i);
+    const v = volumeCol.get(i);
+
+    if (typeof o !== "number") throw new Error(`unexpected open type at row ${i}`);
+    if (typeof h !== "number") throw new Error(`unexpected high type at row ${i}`);
+    if (typeof l !== "number") throw new Error(`unexpected low type at row ${i}`);
+    if (typeof c !== "number") throw new Error(`unexpected close type at row ${i}`);
+    if (typeof v !== "number") throw new Error(`unexpected volume type at row ${i}`);
+
+    open[i] = o;
+    high[i] = h;
+    low[i] = l;
+    close[i] = c;
+    volume[i] = v;
+  }
+
+  return { ts_ms, open, high, low, close, volume };
+}

--- a/visualization/app/src/lib/streaming/loopback_ws.ts
+++ b/visualization/app/src/lib/streaming/loopback_ws.ts
@@ -26,6 +26,13 @@ export type StreamsPullRequest = {
   request_id: string;
 };
 
+export type StreamsCancelRequest = {
+  type: "streams.cancel";
+  stream_id: string;
+  correlation_id: string;
+  request_id: string;
+};
+
 export type StreamsClosedMessage = {
   type: "streams.closed";
   stream_id: string;
@@ -246,8 +253,27 @@ export async function pullLoopbackWsStream(
   let closed: StreamsClosedMessage | null = null;
   let totalBytes = 0;
 
+  let cancelSent = false;
+  const sendCancel = () => {
+    if (cancelSent) return;
+    cancelSent = true;
+    if (ws.readyState !== 1) return;
+    try {
+      const cancel: StreamsCancelRequest = {
+        type: "streams.cancel",
+        stream_id: streamId,
+        correlation_id: correlationId,
+        request_id: requestId,
+      };
+      ws.send(JSON.stringify(cancel));
+    } catch {
+      // best-effort
+    }
+  };
+
   // The caller controls backpressure by awaiting this loop; we only pull again after a chunk arrives.
   try {
+    signal?.addEventListener("abort", sendCancel, { once: true });
     while (eofSeq === null && closed === null) {
       if (expectedSeq > BigInt(Number.MAX_SAFE_INTEGER)) {
         throw new Error(
@@ -390,6 +416,7 @@ export async function pullLoopbackWsStream(
       }
     }
   } finally {
+    signal?.removeEventListener("abort", sendCancel);
     q.dispose();
   }
 

--- a/visualization/app/src/lib/tauri/envelope.ts
+++ b/visualization/app/src/lib/tauri/envelope.ts
@@ -1,0 +1,7 @@
+export function makeEnvelope(args: { protocolVersion: string; correlationId: string }) {
+  return {
+    protocol_version: args.protocolVersion,
+    correlation_id: args.correlationId,
+    request_id: crypto.randomUUID(),
+  };
+}

--- a/visualization/app/src/lib/tauri/websocket.ts
+++ b/visualization/app/src/lib/tauri/websocket.ts
@@ -1,0 +1,15 @@
+import type { WsLike } from "@/lib/streaming/loopback_ws";
+
+export const createBrowserWebSocket = (args: {
+  url: string;
+  authToken: string;
+  tokenIn: string;
+}): WsLike => {
+  const { url, authToken, tokenIn } = args;
+  if (tokenIn !== "sec-websocket-protocol") {
+    throw new Error(`unsupported token_in: ${tokenIn}`);
+  }
+  const ws = new WebSocket(url, authToken);
+  ws.binaryType = "arraybuffer";
+  return ws as unknown as WsLike;
+};

--- a/visualization/app/src/types/apache-arrow.d.ts
+++ b/visualization/app/src/types/apache-arrow.d.ts
@@ -1,0 +1,8 @@
+declare module "apache-arrow" {
+  export type Table = any;
+
+  export function tableFromIPC(bytes: Uint8Array | ArrayBuffer): Table;
+  export function tableToIPC(table: any, options?: any): Uint8Array;
+  export function tableFromArrays(arrays: Record<string, any>): Table;
+}
+


### PR DESCRIPTION
Implements the first end-to-end visualization slice for **candles**.

Frontend
- Adds `candles.query` client that pulls Arrow IPC over PRD-18 loopback WS and decodes `candles.ohlcv.f64.v1` into typed arrays.
- Adds a minimal pixel-bound Canvas candles renderer and a `Candles` tab to drive a synthetic dataset end-to-end.
- Adds Vitest coverage for TSR1 pull loop abort→`streams.cancel` and `candlesQueryAndDecode` Arrow decode pipeline.

Host (Tauri)
- Writes Arrow IPC streams as multiple RecordBatches (re-batching) so each IPC message stays under `limits::MAX_CHUNK_BYTES` (fixes PRD-18 chunking requirement).
- Adds hard caps for pending (not-yet-consumed) streams to avoid OOM if the UI never connects.
- Adds a regression test that queries ~`MAX_TARGET_POINTS` and verifies streaming still decodes.

PRDs
- PRD-17 pixel-bound request pattern
- PRD-18 pull-based streaming, cancel semantics, chunk size invariants
- PRD-20 performance: typed arrays + canvas-first rendering
